### PR TITLE
FEATURE Module can check a first post for spam keywords and notify an admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Cam Findlay <cam@silverstripe.com>
 
 ## Requirements ##
  * SilverStripe 3.1 (Framework and CMS)
- * [Forum module 0.7 (compatible with 3.1 SilverStripe core)](https://github.com/silverstripe/silverstripe-forum)
+ * [Forum module 0.8 (compatible with 3.1 SilverStripe core)](https://github.com/silverstripe/silverstripe-forum)
 
 ## Installation ##
 
@@ -19,7 +19,7 @@ Best practice is to install via composer (otherwise download files and unzip to 
 
     composer require camfindlay/silverstripe-suspendspammer dev-master
 
-Run dev/build in the browser (http://<yourwebsite>/dev/build?flush=all) 
+Run dev/build in the browser (http://yourwebsite/dev/build?flush=all) 
 
 or 
 
@@ -28,8 +28,7 @@ via command line
     sake (cd <yourwebroot> && ./sapphire/sake dev/build flush=all)
 
 ## Usage ##
-Simply go to the CMS, access the *Spam Keywords* menu then add any spam related keywords you wish to check when a new 
-member registers. 
+Simply go to the CMS, access the *Spam Keywords* menu then add any spam related keywords you wish to check when a new member registers or posts the content of their first forum post. 
 
 By default SuspendSpammer check the Occupation and Company fields (added by the silverstripe/forum module). 
 This can be changed by setting the following static in your _config/config.yml file and supplying an array of keywords.
@@ -40,11 +39,10 @@ This can be changed by setting the following static in your _config/config.yml f
         - Company
         - AnyOtherKeywords
 
-You can also create a CSV file of keywords using the column heading 'Title' and import through the default ModelAdmin 
-importer.
+You can also create a CSV file of keywords using the column heading 'Title' and import through the default ModelAdmin importer.
 
 ## Email Notifications ##
-In order to be notified when a suspected spam registration is automatically suspended you can enable email notification and designate an email address to receive the notification emails. 
+In order to be notified when a suspected spam registration or post is automatically suspended you can enable email notification and designate an email address to receive the notification emails. 
 
 The notification email includes the email address of the suspected spammer (so you can look them up in the Security section of SilverStripe CMS) as well as the fields set in the '$fields_to_check' against which the spam keywords matched. 
 
@@ -54,7 +52,7 @@ To enable set the following in your *_config/config.yml* file:
     
     Admin:
       admin_email: 'admin@yourdomain.com'
-    Member:
+    SuspendSpammerEmail:
       email_to: you@yourdomain.com
       enable_email: true
     

--- a/_config/suspendspammer.yml
+++ b/_config/suspendspammer.yml
@@ -6,4 +6,8 @@ After:
 ---
 Member:
   extensions:
-    - SuspendSpammerExtension
+    - SuspendSpammerMemberExtension
+Forum_Controller:
+  extensions:
+    - SuspendSpammerForumControllerExtension
+  

--- a/code/SuspendSpammerEmail.php
+++ b/code/SuspendSpammerEmail.php
@@ -1,0 +1,37 @@
+<?php
+
+//Email the admin to let them know to check the registration and re-enable if it was a false positive.
+
+class SuspendSpammerEmail extends Email {
+  
+  //enable emails to be sent to admin on suspected spammer registrations and posts.
+  private static $enable_email = false;
+
+  //Email address to send ghosted registrations and posts to for review.
+  private static $email_to;
+  
+  protected $ss_template = "SuspendSpammerEmail";
+
+    public function __construct($content) {
+        //Email is not set as on - none shall pass...
+        if(!$this->config()->enable_email){
+          return;
+        }
+          
+        //Check for a to and throw error if none set.
+        if(!$this->config()->email_to){
+          user_error("You have not set an 'email_to' in the config", E_USER_ERROR);
+          return;
+        }
+        
+        $from = Config::inst()->get('Email', 'admin_email');
+        $to = $this->config()->email_to;
+        $subject = "Suspected spammer: Please review";
+        
+        parent::__construct($from, $to, $subject);
+
+        $this->populateTemplate(new ArrayData(array(
+            'Content' => $content
+        )));
+    }  
+}

--- a/code/SuspendSpammerForumControllerExtension.php
+++ b/code/SuspendSpammerForumControllerExtension.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Suspends a suspected spammer post based on user input of common spammer related words.
+ *
+ * @author Cam Findlay <cam@silverstripe.com>
+ * @package suspendspammer
+ */
+class SuspendSpammerForumControllerExtension extends DataExtension {
+
+	public function beforePostMessage($data, $member = null){
+		if(!$member){
+			$member = Member::currentUser();
+		}
+		
+		//If member has CMS access they don't need to be checked out.
+		if(Permission::check('CMS_ACCESS_CMSMain', 'any', $member)){
+			return;
+		}
+		
+		//Is this the Members first message and they are not already a ghost or banned.
+		if($member->ForumStatus == 'Normal' && $member->NumPosts() == 0
+		){
+			
+			$content = $data['Title'] .' '. $data['Content'];
+			
+			//Check title and content for spam keywords.
+			$spam_words = SuspendSpammerKeyword::get();
+			
+			//ensure it returns as an array.
+			if($spam_words->Exists()) {
+				
+				$spam_words = $spam_words->map()->toArray();
+				$matches = array();
+				
+				//Check words for known spammer content
+				$matchFound = preg_match_all(
+									"/\b(" . implode($spam_words,"|") . ")\b/i", 
+									$content, 
+									$matches
+								);
+				
+				//@TODO do phone number pattern recognittion in the future as this is a 
+				//common indication of the human spammers this module is design to counter.
+
+				if($matchFound) {
+					//If true, ghost the member.
+					$member->ForumStatus = 'Ghost';
+					$member->write();
+					
+					//Email the admin
+					if(Config::inst()->get('SuspendSpammerEmail', 'enable_email')) {
+							$body = "<h1>Suspected Spammer Post</h1>
+							<p>Email: " . $member->Email . "</p>
+							<p>" . $content . "</p>";
+
+							SuspendSpammerEmail::create($body)
+								->send();
+					}
+					
+				}
+				
+			}
+						
+		}
+		
+	}
+
+}

--- a/code/SuspendSpammerKeyword.php
+++ b/code/SuspendSpammerKeyword.php
@@ -15,7 +15,18 @@ class SuspendSpammerKeyword extends DataObject {
 	private static $field_labels = array(
 		'Title' => 'Spam Keyword'
 	);
+	
+	public function requireDefaultRecords() {
+			parent::requireDefaultRecords();
+			//Ensure at least 1 spam keyword exists.
+			if( !SuspendSpammerKeyword::get()->Exists() ) {
+				$keyword = SuspendSpammerKeyword::create();
+				$keyword->Title = 'astrologer';
+				$keyword->write();
+			}
 
+		}
+		
 	/**
 	 * Trims and makes the keywords lowercase for comparison.
 	 */

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,9 @@
                 }
         ],
         "require": {
-                "silverstripe/framework": "~3.1.0",
-                 "silverstripe/cms": "~3.1.0",
-                 "silverstripe/forum": "~0.8.0"
+                "silverstripe/framework": "~3.1",
+                 "silverstripe/cms": "~3.1",
+                 "silverstripe/forum": "~0.8"
         },
         "extra": {
                 "installer-name": "suspendspammer"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "require": {
                 "silverstripe/framework": "~3.1.0",
                  "silverstripe/cms": "~3.1.0",
-                 "silverstripe/forum": "~0.7.0"
+                 "silverstripe/forum": "~0.8.0"
         },
         "extra": {
                 "installer-name": "suspendspammer"

--- a/templates/email/SuspendSpammerEmail.ss
+++ b/templates/email/SuspendSpammerEmail.ss
@@ -1,0 +1,1 @@
+$Content


### PR DESCRIPTION
There has also be some major API updates and configuration changes. Hence this is a new major version of this module.

It also tracks against the 0.8 version of forum (currently not yet stable). 

It can check for spammer keywords at both registration and on the first post to give the best chance of catching highest % of human spammers.